### PR TITLE
#16 Add npm & travis badges to README

### DIFF
--- a/linting/stylelint-config-bitcrowd/README.md
+++ b/linting/stylelint-config-bitcrowd/README.md
@@ -1,5 +1,7 @@
 # stylelint-config-bitcrowd
 
+[![npm version](https://badge.fury.io/js/stylelint-config-bitcrowd.svg)](https://badge.fury.io/js/stylelint-config-bitcrowd)
+
 This package provides bitcrowd’s `.stylelintrc` as an extensible shared config.
 
 It is derived from [stylelint-config-standard](https://github.com/stylelint/stylelint-config-standard).


### PR DESCRIPTION
**WIP**

Adds npm package badge to stylelint-config-bitcrowd README

**TODO**
Add travis badge to the same README

Fixes #16 